### PR TITLE
fix: Use display name for iterations and update spock version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 name=agent-java-spock
 version=5.1.1-SNAPSHOT
 description=Spock integration agent for Report Portal
-spock_version=1.3-groovy-2.5
+spock_version=2.3-groovy-2.5
 junit5_version=5.6.3
 junit5_launcher_version=1.6.3
 mockito_version=3.11.2

--- a/src/main/java/com/epam/reportportal/spock/ReportPortalSpockListener.java
+++ b/src/main/java/com/epam/reportportal/spock/ReportPortalSpockListener.java
@@ -229,7 +229,7 @@ public class ReportPortalSpockListener extends AbstractRunListener {
 
 	@Nonnull
 	protected StartTestItemRQ buildIterationItemRq(@Nonnull IterationInfo iteration) {
-		StartTestItemRQ rq = buildBaseStartTestItemRq(iteration.getName(), ITEM_TYPES_REGISTRY.get(FEATURE));
+		StartTestItemRQ rq = buildBaseStartTestItemRq(iteration.getDisplayName(), ITEM_TYPES_REGISTRY.get(FEATURE));
 		rq.setDescription(buildIterationDescription(iteration));
 		MethodInfo featureMethodInfo = iteration.getFeature().getFeatureMethod();
 		String codeRef = extractCodeRef(featureMethodInfo);


### PR DESCRIPTION
Currently this project uses an old version of `spock-core`. This give a problem with unrolled iteration names. I would expect to see the value of the parameter.
![Screenshot 2023-01-05 at 16-54-29 Report Portal](https://user-images.githubusercontent.com/103176392/210824786-d2ac21f7-dc04-46fc-acca-2a58cb441769.png)

This PR should resolve this issue by updating the `spock-core` dependency and using the `IterationInfo#getDisplayName` method. While developing this PR I've used the following spec to test:
```groovy
import spock.lang.Specification
import spock.lang.Unroll

class UnrollSpec extends Specification {

    @Unroll
    def "maximum of numbers #a and #b is #c"(int a, int b, int c) {
        expect:
        Math.max(a, b) == c

        where:
        a | b | c
        1 | 3 | 3
        7 | 4 | 7
        0 | 0 | 0
    }
}
```
The result of the PR is shown in the image below:

![Screenshot 2023-01-05 at 16-55-49 Report Portal](https://user-images.githubusercontent.com/103176392/210824664-49d2f228-05fd-445a-afea-b01e73bc9fe6.png)