### PR TITLE
RPP_Agents_Java_Spock_LastErrorLog - Task is to add a new feature to …

### DIFF
--- a/src/test/groovy/com/epam/reportportal/spock/description/ConditionNotSatisfiedErrorMessageWithoutDescriptionTest.java
+++ b/src/test/groovy/com/epam/reportportal/spock/description/ConditionNotSatisfiedErrorMessageWithoutDescriptionTest.java
@@ -1,0 +1,80 @@
+package com.epam.reportportal.spock.description;
+
+import com.epam.reportportal.listeners.ItemStatus;
+import com.epam.reportportal.service.ReportPortal;
+import com.epam.reportportal.service.ReportPortalClient;
+import com.epam.reportportal.spock.ReportPortalSpockListener;
+import com.epam.reportportal.spock.features.fail.HelloSpockSpecFailed;
+import com.epam.reportportal.spock.utils.TestExtension;
+import com.epam.reportportal.spock.utils.TestUtils;
+import com.epam.reportportal.util.test.CommonUtils;
+import com.epam.ta.reportportal.ws.model.FinishTestItemRQ;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.epam.reportportal.spock.utils.TestUtils.runClasses;
+import static com.epam.reportportal.spock.utils.TestUtils.standardParameters;
+import static com.epam.reportportal.spock.utils.TestUtils.testExecutor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ConditionNotSatisfiedErrorMessageWithoutDescriptionTest {
+
+    private final String classId = CommonUtils.namedId("class_");
+    private final String methodId = CommonUtils.namedId("method_");
+    private final List<String> nestedSteps = Stream.generate(() -> CommonUtils.namedId("method_")).limit(3).collect(Collectors.toList());
+    private final List<Pair<String, String>> nestedStepsLink = nestedSteps.stream().map(s -> Pair.of(methodId, s)).collect(Collectors.toList());
+
+    private final ReportPortalClient client = mock(ReportPortalClient.class);
+
+    private static final String ERROR_DESCRIPTION = "Error:\nCondition not satisfied:\n\nname.size() == length\n|    |      |  |\n|    6      |  7\nScotty      false\n";
+
+
+    @BeforeEach
+    public void setupMock() {
+        TestUtils.mockLaunch(client, null, classId, methodId);
+        TestUtils.mockNestedSteps(client, nestedStepsLink);
+        TestUtils.mockBatchLogging(client);
+        TestExtension.listener = new ReportPortalSpockListener(ReportPortal.create(client, standardParameters(), testExecutor()));
+    }
+
+    @Test
+    public void verify_error_condition_not_satisfied_message_without_description() {
+
+        TestExecutionSummary result = runClasses(HelloSpockSpecFailed.class);
+
+        assertThat(result.getTotalFailureCount(), equalTo(1L));
+
+        ArgumentCaptor<FinishTestItemRQ> finishNestedStepCaptor = ArgumentCaptor.forClass(FinishTestItemRQ.class);
+        nestedSteps.forEach(s -> verify(client).finishTestItem(eq(s), finishNestedStepCaptor.capture()));
+
+        List<FinishTestItemRQ> passedFinishItemStatuses = finishNestedStepCaptor.getAllValues().stream()
+                .filter(finishTestItemRQ -> finishTestItemRQ.getStatus().equals(ItemStatus.PASSED.name()))
+                .collect(Collectors.toList());
+
+        assertThat(passedFinishItemStatuses, hasSize(2));
+
+        passedFinishItemStatuses.forEach(finishTestItemRQ -> assertThat(finishTestItemRQ.getDescription(), is(nullValue())));
+
+        List<FinishTestItemRQ> failedFinishItemStatuses = finishNestedStepCaptor.getAllValues().stream()
+                .filter(finishTestItemRQ -> finishTestItemRQ.getStatus().equals(ItemStatus.FAILED.name()))
+                .collect(Collectors.toList());
+
+        assertThat(failedFinishItemStatuses, hasSize(1));
+
+        assertThat(failedFinishItemStatuses.iterator().next().getDescription(), equalTo(ERROR_DESCRIPTION));
+    }
+}

--- a/src/test/groovy/com/epam/reportportal/spock/description/ExceptionErrorMessageWithDescriptionTest.java
+++ b/src/test/groovy/com/epam/reportportal/spock/description/ExceptionErrorMessageWithDescriptionTest.java
@@ -1,0 +1,69 @@
+package com.epam.reportportal.spock.description;
+
+import com.epam.reportportal.listeners.ItemStatus;
+import com.epam.reportportal.service.ReportPortal;
+import com.epam.reportportal.service.ReportPortalClient;
+import com.epam.reportportal.spock.ReportPortalSpockListener;
+import com.epam.reportportal.spock.features.fail.FailsInDifferentMethod;
+import com.epam.reportportal.spock.utils.TestExtension;
+import com.epam.reportportal.spock.utils.TestUtils;
+import com.epam.reportportal.util.test.CommonUtils;
+import com.epam.ta.reportportal.ws.model.FinishTestItemRQ;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.epam.reportportal.spock.utils.TestUtils.runClasses;
+import static com.epam.reportportal.spock.utils.TestUtils.standardParameters;
+import static com.epam.reportportal.spock.utils.TestUtils.testExecutor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ExceptionErrorMessageWithDescriptionTest {
+
+    private final String launchId = CommonUtils.namedId("launch_");
+    private final String classId = CommonUtils.namedId("class_");
+    private final List<String> methodIds = Stream.generate(() -> CommonUtils.namedId("method_")).limit(1).collect(Collectors.toList());
+
+    private final ReportPortalClient client = mock(ReportPortalClient.class);
+
+    private static final String ERROR_DESCRIPTION_EXCEPTION = "Setup: \nError:\njava.lang.IllegalStateException: Some test flow failure";
+
+    @BeforeEach
+    public void setupMock() {
+        TestUtils.mockLaunch(client, launchId, classId, methodIds);
+        TestUtils.mockBatchLogging(client);
+        TestExtension.listener = new ReportPortalSpockListener(ReportPortal.create(client, standardParameters(), testExecutor()));
+    }
+
+    @Test
+    public void verify_error_exception_message_with_description() {
+
+        TestUtils.mockLaunch(client, launchId, classId, methodIds);
+        TestExtension.listener = new ReportPortalSpockListener(ReportPortal.create(client, standardParameters(), testExecutor()));
+
+        TestExecutionSummary result = runClasses(FailsInDifferentMethod.class);
+
+        assertThat(result.getTotalFailureCount(), equalTo(1L));
+
+        ArgumentCaptor<FinishTestItemRQ> finishStepCaptor = ArgumentCaptor.forClass(FinishTestItemRQ.class);
+
+        methodIds.forEach(s -> verify(client).finishTestItem(eq(s), finishStepCaptor.capture()));
+
+        List<FinishTestItemRQ> failedFinishItemStatuses = finishStepCaptor.getAllValues().stream()
+                .filter(fis -> fis.getStatus().equals(ItemStatus.FAILED.name()))
+                .collect(Collectors.toList());
+
+        assertThat(failedFinishItemStatuses, hasSize(1));
+        assertThat(failedFinishItemStatuses.iterator().next().getDescription(), equalTo(ERROR_DESCRIPTION_EXCEPTION));
+    }
+}

--- a/src/test/groovy/com/epam/reportportal/spock/description/ExceptionWithoutErrorMessageWithDescriptionTest.java
+++ b/src/test/groovy/com/epam/reportportal/spock/description/ExceptionWithoutErrorMessageWithDescriptionTest.java
@@ -1,0 +1,70 @@
+package com.epam.reportportal.spock.description;
+
+import com.epam.reportportal.listeners.ItemStatus;
+import com.epam.reportportal.service.ReportPortal;
+import com.epam.reportportal.service.ReportPortalClient;
+import com.epam.reportportal.spock.ReportPortalSpockListener;
+import com.epam.reportportal.spock.features.fail.FailWithExceptionWithoutMessage;
+import com.epam.reportportal.spock.utils.TestExtension;
+import com.epam.reportportal.spock.utils.TestUtils;
+import com.epam.reportportal.util.test.CommonUtils;
+import com.epam.ta.reportportal.ws.model.FinishTestItemRQ;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.epam.reportportal.spock.utils.TestUtils.runClasses;
+import static com.epam.reportportal.spock.utils.TestUtils.standardParameters;
+import static com.epam.reportportal.spock.utils.TestUtils.testExecutor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ExceptionWithoutErrorMessageWithDescriptionTest {
+
+    private final String launchId = CommonUtils.namedId("launch_");
+    private final String classId = CommonUtils.namedId("class_");
+    private final List<String> methodIds = Stream.generate(() -> CommonUtils.namedId("method_")).limit(1).collect(Collectors.toList());
+
+    private final ReportPortalClient client = mock(ReportPortalClient.class);
+
+    private static final String ERROR_DESCRIPTION_EXCEPTION = "Setup: \nWhen: \nThen: \nError:\njava.util.NoSuchElementException";
+
+    @BeforeEach
+    public void setupMock() {
+        TestUtils.mockLaunch(client, launchId, classId, methodIds);
+        TestUtils.mockBatchLogging(client);
+        TestExtension.listener = new ReportPortalSpockListener(ReportPortal.create(client, standardParameters(), testExecutor()));
+    }
+
+    @Test
+    public void verify_exception_without_error_message_with_description() {
+
+        TestUtils.mockLaunch(client, launchId, classId, methodIds);
+        TestExtension.listener = new ReportPortalSpockListener(ReportPortal.create(client, standardParameters(), testExecutor()));
+
+        TestExecutionSummary result = runClasses(FailWithExceptionWithoutMessage.class);
+
+        assertThat(result.getTotalFailureCount(), equalTo(1L));
+
+        ArgumentCaptor<FinishTestItemRQ> finishStepCaptor = ArgumentCaptor.forClass(FinishTestItemRQ.class);
+
+        methodIds.forEach(s -> verify(client).finishTestItem(eq(s), finishStepCaptor.capture()));
+
+        List<FinishTestItemRQ> failedFinishItemStatuses = finishStepCaptor.getAllValues()
+                .stream()
+                .filter(fis -> fis.getStatus().equals(ItemStatus.FAILED.name()))
+                .collect(Collectors.toList());
+
+        assertThat(failedFinishItemStatuses, hasSize(1));
+        assertThat(failedFinishItemStatuses.iterator().next().getDescription(), equalTo(ERROR_DESCRIPTION_EXCEPTION));
+    }
+}

--- a/src/test/groovy/com/epam/reportportal/spock/features/fail/FailWithExceptionWithoutMessage.groovy
+++ b/src/test/groovy/com/epam/reportportal/spock/features/fail/FailWithExceptionWithoutMessage.groovy
@@ -1,0 +1,17 @@
+package com.epam.reportportal.spock.features.fail
+
+import spock.lang.Specification
+
+class FailWithExceptionWithoutMessage extends Specification {
+
+    def "should demonstrate NoSuchElementException given-when-then fail"() {
+        given:
+        def polygon = new ArrayList()
+
+        when:
+        polygon.size()
+
+        then:
+        throw new NoSuchElementException()
+    }
+}


### PR DESCRIPTION
Task is to add a new feature to RP agent for Spock.
Feature - add last error log to step description. In RP there is an entity 'step' and it can have different data inside - in particular logs. It is the only step with some statistics, in fact. When during step execution an error occurs (log with Error level) it is needed to add this information to step description (a field of the 'step' entity). 
There is a method for setting description: https://github.com/reportportal/commons-model/blob/develop/src/main/java/com/epam/ta/reportportal/ws/model/FinishExecutionRQ.java#L69
Take into account that description can have some information - need to append an error text, not to overwrite description value.
Description should be updated only for Step (not for Nested step - it doesn't have description).
Unit-tests must be implemented

Task description in EWORK:
https://ework.cirro.io/engineer/projects/7b2d93db-978a-46dc-9616-91a46cec7109